### PR TITLE
Update Gen2k.py

### DIFF
--- a/Gen2k.py
+++ b/Gen2k.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python2
-
+# -*- coding: utf-8 -*-
 __author__    = 'irenicus09'
 __email__     = 'irenicus09[at]gmail[dot]com'
 __license__   = 'BSDv4'


### PR DESCRIPTION
Fixed encoding issue.
  File "./Gen2k.py", line 16
SyntaxError: Non-ASCII character '\xc2' in file ./Gen2k.py on line 17, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details